### PR TITLE
np.bool is deprecated

### DIFF
--- a/src/envs/starcraft/StarCraft2Env.py
+++ b/src/envs/starcraft/StarCraft2Env.py
@@ -327,10 +327,10 @@ class StarCraft2Env(MultiAgentEnv):
                 self.map_x, int(self.map_y / 8))
             self.pathing_grid = np.transpose(np.array([
                 [(b >> i) & 1 for b in row for i in range(7, -1, -1)]
-                for row in vals], dtype=np.bool))
+                for row in vals], dtype=bool))
         else:
             self.pathing_grid = np.invert(np.flip(np.transpose(np.array(
-                list(map_info.pathing_grid.data), dtype=np.bool).reshape(
+                list(map_info.pathing_grid.data), dtype=bool).reshape(
                     self.map_x, self.map_y)), axis=1))
 
         self.terrain_height = np.flip(
@@ -1201,7 +1201,7 @@ class StarCraft2Env(MultiAgentEnv):
         """
         arr = np.zeros(
             (self.n_agents, self.n_agents + self.n_enemies), 
-            dtype=np.bool,
+            dtype=bool,
         )
 
         for agent_id in range(self.n_agents):


### PR DESCRIPTION
```np.bool``` is deprecated at numpy 1.20.
The latest version is numpy 1.26.0.